### PR TITLE
Add added security for password field

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -1,15 +1,15 @@
 apply plugin: 'com.android.application'
 
 android {
-    compileSdkVersion 25
-    buildToolsVersion '25.0.0'
+    compileSdkVersion 27
+    buildToolsVersion '27.0.3'
     defaultConfig {
         applicationId "com.uploadedlobster.PwdHash"
-        minSdkVersion 9
-        targetSdkVersion 25
+        minSdkVersion 14
+        targetSdkVersion 27
         testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
-        versionCode 24
-        versionName '1.3.13'
+        versionCode 25
+        versionName '1.3.14'
     }
     buildTypes {
         release {
@@ -21,12 +21,9 @@ android {
 }
 
 dependencies {
-    compile 'com.android.support:support-v4:25.0.0'
-    testCompile 'junit:junit:4.12'
-    androidTestCompile 'com.android.support:support-annotations:25.0.0'
-    androidTestCompile 'com.android.support.test:runner:0.5'
-    androidTestCompile 'com.android.support.test:rules:0.5'
-    androidTestCompile('com.android.support.test.espresso:espresso-core:2.2.2', {
-        exclude group: 'com.android.support', module: 'support-annotations'
-    })
+    implementation 'com.android.support:support-v4:27.1.0'
+    testImplementation 'junit:junit:4.12'
+    androidTestImplementation 'com.android.support:support-annotations:27.1.0'
+    androidTestCompile 'com.android.support.test.espresso:espresso-core:3.0.1'
+    androidTestCompile 'com.android.support.test:runner:1.0.1'
 }

--- a/app/src/main/res/layout/main.xml
+++ b/app/src/main/res/layout/main.xml
@@ -35,7 +35,7 @@
 	        android:layout_width="match_parent"
 	        android:layout_height="wrap_content"
 	        android:inputType="textPassword"
-	        android:imeOptions="actionDone" />
+			android:imeOptions="actionDone|flagNoPersonalizedLearning"/>
 	
 	    <LinearLayout
 	        style="@style/Label"

--- a/build.gradle
+++ b/build.gradle
@@ -2,14 +2,22 @@
 buildscript {
     repositories {
         jcenter()
+        maven {
+            url 'https://maven.google.com/'
+            name 'Google'
+        }
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.2.2'
+        classpath 'com.android.tools.build:gradle:3.1.0'
     }
 }
 
 allprojects {
     repositories {
         jcenter()
+        maven {
+            url 'https://maven.google.com/'
+            name 'Google'
+        }
     }
 }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-2.14.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.4-all.zip


### PR DESCRIPTION
By adding the following flag, keyboards are told to not learn what is typed. Most keyboards should already have this set to TRUE by the fact that it is a password field, but this seems like an easy win for possibly extra protection.

For example, Google Keyboard becomes anonymous when on this field, as can be seen in this pic (look at the faded keyboard background): https://ibb.co/kdM9H7

Additionally, since this is a new flag I've updated the platform tooling and target version to the latest stable. The Intrumentation Tests still pass as expected :)

