### PR TITLE
Passwords should be invisible to the accessibility services

### DIFF
--- a/app/src/main/res/layout/main.xml
+++ b/app/src/main/res/layout/main.xml
@@ -35,6 +35,7 @@
 	        android:layout_width="match_parent"
 	        android:layout_height="wrap_content"
 	        android:inputType="textPassword"
+			android:importantForAccessibility="no"
 			android:imeOptions="actionDone|flagNoPersonalizedLearning"/>
 	
 	    <LinearLayout


### PR DESCRIPTION
Due to recent attacks, malicious apps that are using the accessibility service can capture all user inputs. In this case, the passwords should be ignored for the accessibility service, so such attacks cannot happen. This is done by our research project in CISPA, Saarland University, Germany.